### PR TITLE
Language keys in tours cannot be overridden

### DIFF
--- a/administrator/components/com_guidedtours/src/Helper/GuidedtoursHelper.php
+++ b/administrator/components/com_guidedtours/src/Helper/GuidedtoursHelper.php
@@ -11,30 +11,42 @@
 namespace Joomla\Component\Guidedtours\Administrator\Helper;
 
 use Joomla\CMS\Factory;
+use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
- * guidedtours component helper.
+ * Guided Tours component helper.
  *
  * @since __DEPLOY_VERSION__
  */
 class GuidedtoursHelper
 {
-    public static function getTourTitle($id)
+    /**
+     * Get a tour title
+     *
+     * @param   int  $id  Id of a tour
+     *
+     * @return  object
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function getTourTitle(int $id): object
     {
         if (empty($id)) {
-            // Throw an error or ...
             return "";
         }
 
-        $db = Factory::getDbo();
+        $db    = Factory::getDbo();
         $query = $db->getQuery(true);
-        $query->select('title');
-        $query->from('#__guidedtours');
-        $query->where('id = ' . $id);
+
+        $query->select('title')
+            ->from($db->quoteName('#__guidedtours'))
+            ->where($db->quoteName('id') . ' = :id')
+            ->bind(':id', $id, ParameterType::INTEGER);
+
         $db->setQuery($query);
 
         return $db->loadObject();

--- a/administrator/components/com_guidedtours/src/Helper/StepHelper.php
+++ b/administrator/components/com_guidedtours/src/Helper/StepHelper.php
@@ -12,28 +12,70 @@ namespace Joomla\Component\Guidedtours\Administrator\Helper;
 
 use Joomla\CMS\Factory;
 use Joomla\CMS\Helper\ContentHelper;
+use Joomla\Database\ParameterType;
 
 // phpcs:disable PSR1.Files.SideEffects
 \defined('_JEXEC') or die;
 // phpcs:enable PSR1.Files.SideEffects
 
 /**
+ * Guided tour step helper
+ *
  * @since __DEPLOY_VERSION__
  */
 class StepHelper extends ContentHelper
 {
-    public static function getTourLanguage($id)
+    /**
+     * Get a tour language
+     *
+     * @param   int  $id  Id of a tour
+     *
+     * @return  string
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function getTourLanguage(int $id): string
     {
         if (empty($id)) {
-            // Throw an error or ...
             return "*";
         }
 
-        $db = Factory::getDbo();
+        $db    = Factory::getDbo();
         $query = $db->getQuery(true);
-        $query->select('language');
-        $query->from('#__guidedtours');
-        $query->where('id = ' . $id);
+
+        $query->select('language')
+            ->from($db->quoteName('#__guidedtours'))
+            ->where($db->quoteName('id') . ' = :id')
+            ->bind(':id', $id, ParameterType::INTEGER);
+
+        $db->setQuery($query);
+
+        return $db->loadResult();
+    }
+
+    /**
+     * Check if a tour is locked
+     *
+     * @param   int  $id  Id of a tour
+     *
+     * @return  boolean
+     *
+     * @since  __DEPLOY_VERSION__
+     */
+    public static function getTourLocked(int $id): bool
+    {
+        if (empty($id)) {
+            return false;
+        }
+
+        $db    = Factory::getDbo();
+        $query = $db->getQuery(true);
+
+        $query->select('locked')
+            ->from('#__guidedtours')
+            ->where($db->quoteName('id') . ' = :id')
+            ->bind(':id', $id, ParameterType::INTEGER);
+
         $db->setQuery($query);
 
         return $db->loadResult();

--- a/administrator/language/en-GB/com_guidedtours.ini
+++ b/administrator/language/en-GB/com_guidedtours.ini
@@ -94,5 +94,5 @@ COM_GUIDEDTOURS_TYPE_REDIRECT_URL_DESC="Enter the relative URL of the page 
 COM_GUIDEDTOURS_TYPE_REDIRECT_URL_LABEL="URL"
 COM_GUIDEDTOURS_URL_LABEL="URL"
 COM_GUIDEDTOURS_URL_DESC="Enter the relative URL of the page from where you want to Start the tour, e.g administrator/index.php?option=com_guidedtours&view=tours for the tours' list page."
+COM_GUIDEDTOURS_WARNING_TOURLOCKED="Joomla Core Guided Tours are a great starting point for your custom tour. To get started, select the action 'Duplicate' from the tour's list."
 COM_GUIDEDTOURS_XML_DESCRIPTION="Component for managing Guided Tours functionality"
-


### PR DESCRIPTION
Pull Request for Issue #78.

### Summary of Changes

Core tours and their steps, in a multilingual environment, can not be saved or else language keys are overridden. 
The alternative will be to duplicate a tour (including steps) and work from those tours (in the works at the time of this PR).