### PR TITLE
Steps Filter

### DIFF
--- a/administrator/components/com_guidedtours/src/View/Steps/HtmlView.php
+++ b/administrator/components/com_guidedtours/src/View/Steps/HtmlView.php
@@ -108,6 +108,9 @@ class HtmlView extends BaseHtmlView
             throw new GenericDataException(implode("\n", $errors), 500);
         }
 
+        // Unset the tour_id field from activeFilters as we don't filter by tour here.
+        unset($this->activeFilters['tour_id']);
+
         $tour_id = $this->state->get('filter.tour_id');
         $this->isLocked = Multilanguage::isEnabled() && StepHelper::getTourLocked($tour_id);
 


### PR DESCRIPTION
unsets the tour_id from the active filters so that the searchtools open in a closed state

Pull Request for Issue #67 