### PR TITLE
Redesign New/Edit Tour view

### DIFF
--- a/administrator/components/com_guidedtours/tmpl/tour/edit.php
+++ b/administrator/components/com_guidedtours/tmpl/tour/edit.php
@@ -35,10 +35,15 @@ $wa->useScript('keepalive')
     <?php if ($this->item->id != 0) : ?>
         <div class="row title-alias form-vertical mb-3">
             <div class="col-12">
-                <?php $this->form->setFieldAttribute('title_translation', 'label', Text::sprintf('COM_GUIDEDTOURS_TITLE_TRANSLATION', $lang)); ?>
-                <?php echo $this->form->renderField('title_translation'); ?>
+                <div class="control-group">
+                    <div class="control-label">
+                        <label for="title_translation"><?php echo Text::sprintf('COM_GUIDEDTOURS_TITLE_TRANSLATION', $lang); ?></label>
+                    </div>
+                    <div class="controls">
+                        <input id="title_translation" class="form-control" value="<?php echo Text::_($this->item->title); ?>" readonly="readonly" type="text">
+                    </div>
+                </div>
             </div>
-        </div>
     <?php endif; ?>
 
     <div>
@@ -48,20 +53,23 @@ $wa->useScript('keepalive')
         <div class="row">
             <div class="col-lg">
                 <?php echo $this->form->renderField('url'); ?>
-                <?php echo $this->form->renderField('description'); ?>
-
                 <?php if ($this->item->id != 0) : ?>
-                    <?php $this->form->setFieldAttribute('description_translation', 'label', Text::sprintf('COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION', $lang)); ?>
-                    <?php echo $this->form->renderField('description_translation'); ?>
+                    <div class="control-group">
+                        <div class="control-label">
+                            <label for="description_translation"><?php echo Text::sprintf('COM_GUIDEDTOURS_DESCRIPTION_TRANSLATION', $lang); ?></label>
+                        </div>
+                        <div class="controls">
+                            <input id="description_translation" class="form-control" value="<?php echo Text::_($this->item->description); ?>" readonly="readonly" type="text">
+                        </div>
+                    </div>
                 <?php endif; ?>
-
-                <?php echo $this->form->renderField('extensions'); ?>
+                <?php echo $this->form->renderField('description'); ?>
             </div>
-
             <div class="col-md-3">
                 <div class="card card-light">
                     <div class="card-body">
                         <?php echo LayoutHelper::render('joomla.edit.global', $this); ?>
+                        <?php echo $this->form->renderField('extensions'); ?>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
1. Moves component selector from the very bottom of the page where it will be missed to the righthand sidebar just like a category selector.

2. Refactored the code to display Title and Description (en-GB) labels to prevent double translation errors. Now the same code as used in com_menus

3. Moved the readonly Description (en-GB) above the editable description as it was missed at the bottom of the page. Changed it to a text field as there is no need for a readonly field to load the wysiwyg editor.

4. Bonus of 3 is that the Description (en-GB) field is now visibly readonly

### Before
![image](https://user-images.githubusercontent.com/1296369/219320985-0fa174a0-6bf8-4554-a941-54223449ce92.png)
![image](https://user-images.githubusercontent.com/1296369/219321174-00883d30-5d7d-4287-b341-2a43fd17e4b6.png)


### After
![image](https://user-images.githubusercontent.com/1296369/219320617-539a2a16-b1ac-4022-bc88-97bdc97d262d.png)
