### PR TITLE
add inline help

### DIFF
--- a/administrator/components/com_guidedtours/forms/step.xml
+++ b/administrator/components/com_guidedtours/forms/step.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form addfieldprefix="Joomla\Component\Guidedtours\Administrator\Field">
-
+	<config>
+		<inlinehelp button="show"/>
+	</config>
 	<field
 		name="id"
 		type="text"

--- a/administrator/components/com_guidedtours/forms/tour.xml
+++ b/administrator/components/com_guidedtours/forms/tour.xml
@@ -1,6 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <form addfieldprefix="Joomla\Component\Guidedtours\Administrator\Field">
-
+	<config>
+		<inlinehelp button="show"/>
+	</config>
 	<field
 		name="id"
 		type="text"

--- a/administrator/components/com_guidedtours/src/View/Step/HtmlView.php
+++ b/administrator/components/com_guidedtours/src/View/Step/HtmlView.php
@@ -146,6 +146,12 @@ class HtmlView extends BaseHtmlView
             );
 
             ToolbarHelper::divider();
+            $inlinehelp  = (string) $this->form->getXml()->config->inlinehelp['button'] == 'show' ?: false;
+            $targetClass = (string) $this->form->getXml()->config->inlinehelp['targetclass'] ?: 'hide-aware-inline-help';
+
+            if ($inlinehelp) {
+                ToolbarHelper::inlinehelp($targetClass);
+            }
             ToolbarHelper::help('Guided_Tours:_New_or_Edit_Step');
         }
     }

--- a/administrator/components/com_guidedtours/src/View/Tour/HtmlView.php
+++ b/administrator/components/com_guidedtours/src/View/Tour/HtmlView.php
@@ -145,6 +145,13 @@ class HtmlView extends BaseHtmlView
         );
 
         ToolbarHelper::divider();
+
+        $inlinehelp  = (string) $this->form->getXml()->config->inlinehelp['button'] == 'show' ?: false;
+        $targetClass = (string) $this->form->getXml()->config->inlinehelp['targetclass'] ?: 'hide-aware-inline-help';
+
+        if ($inlinehelp) {
+            ToolbarHelper::inlinehelp($targetClass);
+        }
         ToolbarHelper::help('Guided_Tours:_New_or_Edit_Tour');
     }
 }


### PR DESCRIPTION
This PR adds the inline help button(toggle) to the tour and step forms

this means that by default the field descriptions are not displayed and only disp[layed on toggle

![image](https://user-images.githubusercontent.com/1296369/219884586-40ffe80e-6ebc-4463-8344-97440c4a2c80.png)
